### PR TITLE
Backport-3.3: etcd v3.4 to v3.3 auto rollback

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -228,6 +228,7 @@ type Config struct {
 	ExperimentalInitialCorruptCheck bool          `json:"experimental-initial-corrupt-check"`
 	ExperimentalCorruptCheckTime    time.Duration `json:"experimental-corrupt-check-time"`
 	ExperimentalEnableV2V3          string        `json:"experimental-enable-v2v3"`
+	ExperimentalVersionDowngrade    bool          `json:"experimental-version-downgrade"`
 }
 
 // configYAML holds the config suitable for yaml parsing

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -174,6 +174,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TokenTTL:                   cfg.AuthTokenTTL,
 		InitialCorruptCheck:        cfg.ExperimentalInitialCorruptCheck,
 		CorruptCheckTime:           cfg.ExperimentalCorruptCheckTime,
+		VersionDowngrade:           cfg.ExperimentalVersionDowngrade,
 		Debug:                      cfg.Debug,
 	}
 

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -220,6 +220,7 @@ func newConfig() *config {
 	// experimental
 	fs.BoolVar(&cfg.ec.ExperimentalInitialCorruptCheck, "experimental-initial-corrupt-check", cfg.ec.ExperimentalInitialCorruptCheck, "Enable to check data corruption before serving any client/peer traffic.")
 	fs.DurationVar(&cfg.ec.ExperimentalCorruptCheckTime, "experimental-corrupt-check-time", cfg.ec.ExperimentalCorruptCheckTime, "Duration of time between cluster corruption check passes.")
+	fs.BoolVar(&cfg.ec.ExperimentalVersionDowngrade, "experimental-version-downgrade", cfg.ec.ExperimentalVersionDowngrade, "Enable to allow only one single minor version downgrade automatically")
 
 	// ignored
 	for _, f := range cfg.ignored {

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -216,7 +216,6 @@ func isCompatibleWithVers(vers map[string]*version.Versions, local types.ID, min
 		}
 		if maxV.LessThan(*clusterv) {
 			plog.Warningf("the running cluster version(%v) is higher than the maximum cluster version(%v) supported", clusterv.String(), maxV.String())
-			return false
 		}
 		ok = true
 	}

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -101,6 +101,8 @@ type ServerConfig struct {
 	// before serving any peer/client traffic.
 	InitialCorruptCheck bool
 	CorruptCheckTime    time.Duration
+	// VersionDowngrade is true to allow minor version downgrade automatically
+	VersionDowngrade    bool
 
 	Debug bool
 }

--- a/etcdserver/membership/cluster.go
+++ b/etcdserver/membership/cluster.go
@@ -513,6 +513,8 @@ func mustDetectDowngrade(cv *semver.Version) {
 	// only keep major.minor version for comparison against cluster version
 	lv = &semver.Version{Major: lv.Major, Minor: lv.Minor}
 	if cv != nil && lv.LessThan(*cv) {
-		plog.Fatalf("cluster cannot be downgraded (current version: %s is lower than determined cluster version: %s).", version.Version, version.Cluster(cv.String()))
+		plog.Warningf("cluster downgrade (current version: %s is lower than determined cluster version: %s).", version.Version, version.Cluster(cv.String()))
+		// overwrite the cluster version restored from snapshot/store with local version determined by the etcd binary version
+		*cv = *lv
 	}
 }

--- a/etcdserver/membership/store.go
+++ b/etcdserver/membership/store.go
@@ -30,7 +30,7 @@ const (
 	attributesSuffix     = "attributes"
 	raftAttributesSuffix = "raftAttributes"
 
-	// the prefix for stroing membership related information in store provided by store pkg.
+	// the prefix for storing membership related information in store provided by store pkg.
 	storePrefix = "/0"
 )
 

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -461,6 +461,9 @@ func restartNode(cfg ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *member
 	plog.Infof("restarting member %s in cluster %s at commit index %d", id, cid, st.Commit)
 	cl := membership.NewCluster("")
 	cl.SetID(cid)
+	if cfg.VersionDowngrade {
+		cl.AllowDowngrade()
+	}
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)
@@ -515,6 +518,9 @@ func restartAsStandaloneNode(cfg ServerConfig, snapshot *raftpb.Snapshot) (types
 
 	plog.Printf("forcing restart of member %s in cluster %s at commit index %d", id, cid, st.Commit)
 	cl := membership.NewCluster("")
+	if cfg.VersionDowngrade {
+		cl.AllowDowngrade()
+	}
 	cl.SetID(cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -319,7 +319,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		if err = membership.ValidateClusterAndAssignIDs(cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
-		if !isCompatibleWithCluster(cl, cl.MemberByName(cfg.Name).ID, prt) {
+		if !isCompatibleWithCluster(cl, cl.MemberByName(cfg.Name).ID, prt, cfg.VersionDowngrade) {
 			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 
@@ -327,6 +327,9 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		cl.SetID(existingCluster.ID())
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.VersionDowngrade {
+			cl.AllowDowngrade()
+		}
 		cfg.Print()
 		id, n, s, w = startNode(cfg, cl, nil)
 	case !haveWAL && cfg.NewCluster:
@@ -361,6 +364,9 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		}
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.VersionDowngrade {
+			cl.AllowDowngrade()
+		}
 		cfg.PrintWithInitial()
 		id, n, s, w = startNode(cfg, cl, cl.MemberIDs())
 	case haveWAL:


### PR DESCRIPTION
Compared to the [public etcd downgrade design](https://docs.google.com/document/d/1mSihXRJz8ROhXf4r5WrBGc8aka-b8HKjo2VDllOc6ac/edit#heading=h.e4jdx621yd8s), I am trying to simplify the manual "whitelisting target downgrade version" process and it doesn't require any server/client side API changes. Once the new `--experimental-version-downgrade` flag is enabled, only v3.4 to v3.3 downgrade is allowed. We can cherry-pick the same change to v3.4 if this feature is stable. 

However, if a user is already using `--experimental-enable-lease-checkpoint` flag to bootstrap a v3.4 cluster, the version downgrade is not possible due to the  [MustUnmarshal](https://github.com/etcd-io/etcd/blob/release-3.3/etcdserver/server.go#L1436-L1442) will panic on `LeaseCheckpoint` internal raft message which doesn't exist in v3.3. As a result, the new added etcd v3.3 flag `--experimental-version-downgrade` is not expected to set to `true`. 

I've excessively tested in two environments and the results look good. 
1. Tested locally first bootstrap with 3 etcd v3.4 servers and then downgrade to v3.3 one by one. It aims to test when the v2 store cluster version request replicate from v3.4 to new v3.3 server, it can be replaced by local 3.3 cluster version. 
2. Tested in a 1.17 kubernetes cluster which by default have 3 etcd v3.4 servers. It amis to test new v3.3 server can recover from the snapshot and replace the cluster version. At the same time when downgrading starts, I ran the sonobuoy e2e conformace test to verify it won't cause k8s functionality regression. 

This is an internal POC PR, once verified successful in EKS, we will make it public as this #12972

Any feedback is welcome, Thanks! 

@gyuho 

