### PR TITLE
*: add "--unsafe-allow-cluster-version-downgrade" for not failing cluster version downgrade

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -183,6 +183,12 @@ type ServerConfig struct {
 	// consider running defrag during bootstrap. Needs to be set to non-zero value to take effect.
 	ExperimentalBootstrapDefragThresholdMegabytes uint `json:"experimental-bootstrap-defrag-threshold-megabytes"`
 
+	// UnsafeAllowClusterVersionDowngrade is "true" to allow cluster version downgrade.
+	// "false" by default, since newer minor versions may introduce incompatible feature changes.
+	// For instance, lease checkpointer request to 3.4 will fail the remaining 3.3 nodes.
+	// But, if one does not use "lease checkpointer" feature, it can be safe to run 3.3 along with 3.4.
+	UnsafeAllowClusterVersionDowngrade bool `json:"unsafe-allow-cluster-version-downgrade"`
+
 	// V2Deprecation defines a phase of v2store deprecation process.
 	V2Deprecation V2DeprecationEnum `json:"v2-deprecation"`
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -89,6 +89,10 @@ const (
 	// v2 API is disabled by default.
 	DefaultEnableV2 = false
 
+	// DefaultUnsafeAllowClusterVersionDowngrade is the default value for "unsafe-allow-cluster-version-downgrade" flag.
+	// unsafe allow cluster version downgrade is disabled by default
+	DefaultUnsafeAllowClusterVersionDowngrade = false
+
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed in ../Documentation/tuning.md#time-parameters.
 	maxElectionMs = 50000
@@ -392,6 +396,12 @@ type Config struct {
 	// ExperimentalTxnModeWriteWithSharedBuffer enables write transaction to use a shared buffer in its readonly check operations.
 	ExperimentalTxnModeWriteWithSharedBuffer bool `json:"experimental-txn-mode-write-with-shared-buffer"`
 
+	// UnsafeAllowClusterVersionDowngrade is "true" to allow cluster version downgrade.
+	// "false" by default, since newer minor versions may introduce incompatible feature changes.
+	// For instance, lease checkpointer request to 3.4 will fail the remaining 3.3 nodes.
+	// But, if one does not use "lease checkpointer" feature, it can be safe to run 3.3 along with 3.4.
+	UnsafeAllowClusterVersionDowngrade bool `json:"unsafe-allow-cluster-version-downgrade"`
+
 	// V2Deprecation describes phase of API & Storage V2 support
 	V2Deprecation config.V2DeprecationEnum `json:"v2-deprecation"`
 }
@@ -489,7 +499,8 @@ func NewConfig() *Config {
 		ExperimentalMemoryMlock:                  false,
 		ExperimentalTxnModeWriteWithSharedBuffer: true,
 
-		V2Deprecation: config.V2_DEPR_DEFAULT,
+		UnsafeAllowClusterVersionDowngrade: DefaultUnsafeAllowClusterVersionDowngrade,
+		V2Deprecation:                      config.V2_DEPR_DEFAULT,
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -223,7 +223,8 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		ExperimentalMemoryMlock:                  cfg.ExperimentalMemoryMlock,
 		ExperimentalTxnModeWriteWithSharedBuffer: cfg.ExperimentalTxnModeWriteWithSharedBuffer,
 		ExperimentalBootstrapDefragThresholdMegabytes: cfg.ExperimentalBootstrapDefragThresholdMegabytes,
-		V2Deprecation: cfg.V2DeprecationEffective(),
+		UnsafeAllowClusterVersionDowngrade:            cfg.UnsafeAllowClusterVersionDowngrade,
+		V2Deprecation:                                 cfg.V2DeprecationEffective(),
 	}
 
 	if srvcfg.ExperimentalEnableDistributedTracing {

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -291,6 +291,7 @@ func newConfig() *config {
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")
+	fs.BoolVar(&cfg.ec.UnsafeAllowClusterVersionDowngrade, "unsafe-allow-cluster-version-downgrade", embed.DefaultUnsafeAllowClusterVersionDowngrade, "true to allow cluster version downgrade, because newer minor versions may introduce incompatible feature changes like lease checkpointer introduced in v3.4")
 	fs.BoolVar(&cfg.ec.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")
 
 	// ignored

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -252,6 +252,9 @@ Unsafe feature:
     Force to create a new one-member cluster.
   --unsafe-no-fsync 'false'
     Disables fsync, unsafe, will cause data loss.
+  --unsafe-allow-cluster-version-downgrade 'false'
+    Allow cluster version downgrade, unsafe, newer minor versions may introduce incompatible feature changes.
+    For instance, experimental lease checkpointer is enabled in 3.4 and downgrade to 3.3 will fail. 
 
 CAUTIOUS with unsafe flag! It may break the guarantees given by the consensus protocol!
 `

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -200,9 +200,10 @@ func decideClusterVersion(lg *zap.Logger, vers map[string]*version.Versions) *se
 }
 
 // allowedVersionRange decides the available version range of the cluster that local server can join in;
-// if the downgrade enabled status is true, the version window is [oneMinorHigher, oneMinorHigher]
-// if the downgrade is not enabled, the version window is [MinClusterVersion, localVersion]
-func allowedVersionRange(downgradeEnabled bool) (minV *semver.Version, maxV *semver.Version) {
+// if the downgrade enabled status is true, the version window is [oneMinorHigherThanLocalVersion, oneMinorHigherThanLocalVersion]
+// otherwise, if the unsafeDowngrade enabled status is true, the version window is [MinClusterVersion, oneMinorHigherThanLocalVersion],
+// if the both downgrade and unsafeDowngrade is not enabled, the version window is [MinClusterVersion, localVersion]
+func allowedVersionRange(downgradeEnabled bool, unsafeDowngradeEnabled bool) (minV *semver.Version, maxV *semver.Version) {
 	minV = semver.Must(semver.NewVersion(version.MinClusterVersion))
 	maxV = semver.Must(semver.NewVersion(version.Version))
 	maxV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
@@ -211,7 +212,15 @@ func allowedVersionRange(downgradeEnabled bool) (minV *semver.Version, maxV *sem
 		// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
 		maxV.Minor = maxV.Minor + 1
 		minV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
+		return minV, maxV
 	}
+
+	// if unsafeDowngrade is enabled, and one minor version down
+	// safe to not fail (e.g., local version 3.4, cluster version 3.5)
+	if unsafeDowngradeEnabled {
+		maxV.Minor = maxV.Minor + 1
+	}
+
 	return minV, maxV
 }
 
@@ -221,9 +230,9 @@ func allowedVersionRange(downgradeEnabled bool) (minV *semver.Version, maxV *sem
 // cluster version in the range of [MinV, MaxV] and no known members has a cluster version
 // out of the range.
 // We set this rule since when the local member joins, another member might be offline.
-func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper) bool {
+func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper, unsafeAllowClusterVersionDowngrade bool) bool {
 	vers := getVersions(lg, cl, local, rt)
-	minV, maxV := allowedVersionRange(getDowngradeEnabledFromRemotePeers(lg, cl, local, rt))
+	minV, maxV := allowedVersionRange(getDowngradeEnabledFromRemotePeers(lg, cl, local, rt), unsafeAllowClusterVersionDowngrade)
 	return isCompatibleWithVers(lg, vers, local, minV, maxV)
 }
 
@@ -256,12 +265,13 @@ func isCompatibleWithVers(lg *zap.Logger, vers map[string]*version.Versions, loc
 			)
 			return false
 		}
+
 		if maxV.LessThan(*clusterv) {
 			lg.Warn(
 				"cluster version of remote member is not compatible; too high",
 				zap.String("remote-member-id", id),
 				zap.String("remote-member-cluster-version", clusterv.String()),
-				zap.String("minimum-cluster-version-supported", minV.String()),
+				zap.String("maximum-cluster-version-supported", maxV.String()),
 			)
 			return false
 		}

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -488,6 +488,9 @@ func restartNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot) (types.ID, 
 	)
 	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
+	if cfg.UnsafeAllowClusterVersionDowngrade {
+		cl.AllowUnsafeDowngrade()
+	}
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)
@@ -562,6 +565,9 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot)
 
 	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
+	if cfg.UnsafeAllowClusterVersionDowngrade {
+		cl.AllowUnsafeDowngrade()
+	}
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -421,7 +421,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		if err = membership.ValidateClusterAndAssignIDs(cfg.Logger, cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
-		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt) {
+		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt, cfg.UnsafeAllowClusterVersionDowngrade) {
 			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 
@@ -429,6 +429,9 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		cl.SetID(types.ID(0), existingCluster.ID())
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.UnsafeAllowClusterVersionDowngrade {
+			cl.AllowUnsafeDowngrade()
+		}
 		id, n, s, w = startNode(cfg, cl, nil)
 		cl.SetID(id, existingCluster.ID())
 
@@ -464,6 +467,9 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		}
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.UnsafeAllowClusterVersionDowngrade {
+			cl.AllowUnsafeDowngrade()
+		}
 		id, n, s, w = startNode(cfg, cl, cl.MemberIDs())
 		cl.SetID(id, cl.ID())
 


### PR DESCRIPTION
Compared to the [public etcd downgrade design](https://docs.google.com/document/d/1mSihXRJz8ROhXf4r5WrBGc8aka-b8HKjo2VDllOc6ac/edit#heading=h.e4jdx621yd8s), I am trying to simplify the manual "whitelisting target downgrade version" process and it doesn't require any server/client side API changes. Once the new `--experimental-version-downgrade` flag is enabled, only one minor version downgrade is allowed (e.g. v3.6 to v3.5). We can cherry-pick the same change to v3.4 and v3.3 if this feature is useful. 

However, if a user is already using `--experimental-enable-lease-checkpoint` flag to bootstrap a v3.4 cluster, the version downgrade is not possible due to the  [MustUnmarshal](https://github.com/etcd-io/etcd/blob/release-3.3/etcdserver/server.go#L1436-L1442) will panic on `LeaseCheckpoint` internal raft message which doesn't exist in v3.3. Not to mention there is no corresponding apply method. As a result, the new added etcd v3.3 flag `--experimental-version-downgrade` is not expected to set to `true` in this case. 

I've excessively tested v3.5 to v3.4 and v3.4 to v3.3 downgrade in two environments and the results look good. 
[TODO Link to two backport PRs]

1. Tested locally first bootstrap with 3 etcd v3.4 servers and then downgrade to v3.3 one by one. It aims to test when the v2 store cluster version request replicate from v3.4 to new v3.3 server, it can be replaced by local 3.3 cluster version. 
2. Tested in a 1.17 kubernetes cluster which by default have 3 etcd v3.4 servers. It amis to test new v3.3 server can recover from the snapshot and replace the cluster version. At the same time when downgrading starts, I ran the sonobuoy e2e conformance test to verify it won't cause k8s functionality regression. 

We understand this is a risky operation without controlling the set of APIs used by the etcd client. But, we would like to put it here for reference, as others may find it useful.

Any feedback is welcome, Thanks! 
