### PR TITLE
Reproduce issue 12535

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -1248,6 +1248,28 @@ func (c *ClusterV3) TakeClient(idx int) {
 	c.mu.Unlock()
 }
 
+func (c *ClusterV3) ReconcileClients(t testing.TB) {
+	c.mu.Lock()
+	for _, client := range c.clients {
+		if client == nil {
+			continue
+		}
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}
+	c.clients = make([]*clientv3.Client, 0)
+	for _, m := range c.Members {
+		client, err := NewClientV3(m)
+		if err != nil {
+			t.Fatalf("cannot create client: %v", err)
+		}
+		c.clients = append(c.clients, client)
+	}
+
+	c.mu.Unlock()
+}
+
 func (c *ClusterV3) Terminate(t testing.TB) {
 	c.mu.Lock()
 	for _, client := range c.clients {


### PR DESCRIPTION
Reproduce issue described in https://github.com/etcd-io/etcd/issues/12535
```
=== RUN   TestIssue12535
    v3_lease_test.go:199: expect revision 17, but got 16
    v3_lease_test.go:202: lease removed but key remains
--- FAIL: TestIssue12535 (1.15s)
FAIL

Process finished with exit code 1
```

```
{
    "level": "warn",
    "ts": "2022-02-08T23:10:35.433Z",
    "caller": "etcdserver/util.go:163",
    "msg": "apply request took too long",
    "took": "20.64µs",
    "expected-duration": "0s",
    "prefix": "",
    "request": "header:<ID:10441453742734613263 > lease_revoke:<id:-000000000000001>",
    "response": "size:27",
    "error": "lease not found"
}
{
    "level": "warn",
    "ts": "2022-02-08T23:10:35.433Z",
    "caller": "etcdserver/util.go:121",
    "msg": "failed to apply request",
    "took": "55.007µs",
    "request": "header:<ID:10441453742734613263 > lease_revoke:<id:-000000000000001>",
    "response": "size:27",
    "error": "lease not found"
}{
    "level": "warn",
    "ts": "2022-02-08T23:10:35.433Z",
    "caller": "etcdserver/util.go:163",
    "msg": "apply request took too long",
    "took": "98.02µs",
    "expected-duration": "0s",
    "prefix": "",
    "request": "header:<ID:10441453742734613263 > lease_revoke:<id:-000000000000001>",
    "response": "size:27"
}
```
The full test log is captured in [test.log](https://github.com/chaochn47/etcd/files/8028178/test.log)


